### PR TITLE
Add login, registration and welcome pages with sessions

### DIFF
--- a/app/api/routers/__init__.py
+++ b/app/api/routers/__init__.py
@@ -1,3 +1,3 @@
-from . import auth, registration
+from . import auth, registration, pages
 
-__all__ = ["auth", "registration"]
+__all__ = ["auth", "registration", "pages"]

--- a/app/api/routers/pages.py
+++ b/app/api/routers/pages.py
@@ -1,0 +1,94 @@
+from fastapi import APIRouter, Request, Depends, Form
+from fastapi.responses import HTMLResponse, RedirectResponse
+from fastapi.templating import Jinja2Templates
+from sqlalchemy.orm import Session
+
+from app.database import get_db
+from app.api.dependencies import authenticate_user
+from app.core.security import get_password_hash
+from app import models
+
+router = APIRouter(tags=["pages"])
+
+templates = Jinja2Templates(directory="app/templates")
+
+
+@router.get("/login", response_class=HTMLResponse)
+async def login_page(request: Request):
+    return templates.TemplateResponse("login.html", {"request": request})
+
+
+@router.post("/login")
+async def login(
+    request: Request,
+    username: str = Form(...),
+    password: str = Form(...),
+    db: Session = Depends(get_db),
+):
+    user = authenticate_user(db, username, password)
+    if not user:
+        return templates.TemplateResponse(
+            "login.html",
+            {"request": request, "error": "Credenciales inválidas"},
+            status_code=400,
+        )
+    request.session["user_id"] = user.id
+    request.session["user_name"] = user.first_name or user.username
+    return RedirectResponse(url="/welcome", status_code=303)
+
+
+@router.get("/register", response_class=HTMLResponse)
+async def register_page(request: Request):
+    return templates.TemplateResponse("register.html", {"request": request})
+
+
+@router.post("/register")
+async def register(
+    request: Request,
+    first_name: str = Form(...),
+    last_name: str = Form(...),
+    email: str = Form(...),
+    password: str = Form(...),
+    confirm_password: str = Form(...),
+    db: Session = Depends(get_db),
+):
+    if password != confirm_password:
+        return templates.TemplateResponse(
+            "register.html",
+            {"request": request, "error": "Las contraseñas no coinciden"},
+            status_code=400,
+        )
+    existing = db.query(models.User).filter(models.User.username == email).first()
+    if existing:
+        return templates.TemplateResponse(
+            "register.html",
+            {"request": request, "error": "El usuario ya existe"},
+            status_code=400,
+        )
+    user = models.User(
+        username=email,
+        email=email,
+        first_name=first_name,
+        last_name=last_name,
+        hashed_password=get_password_hash(password),
+    )
+    db.add(user)
+    db.commit()
+    return RedirectResponse(url="/login", status_code=303)
+
+
+@router.get("/welcome", response_class=HTMLResponse)
+async def welcome(request: Request):
+    user_id = request.session.get("user_id")
+    if not user_id:
+        return RedirectResponse(url="/login", status_code=303)
+    user_name = request.session.get("user_name", "Usuario")
+    return templates.TemplateResponse(
+        "welcome.html", {"request": request, "user_name": user_name}
+    )
+
+
+@router.post("/logout")
+async def logout(request: Request):
+    request.session.clear()
+    return RedirectResponse(url="/login", status_code=303)

--- a/app/main.py
+++ b/app/main.py
@@ -1,5 +1,8 @@
 from fastapi import FastAPI
-from app.api.routers import auth, registration
+from fastapi.staticfiles import StaticFiles
+from starlette.middleware.sessions import SessionMiddleware
+
+from app.api.routers import auth, registration, pages
 from app.database import Base, engine, SessionLocal
 from app.services.logging_middleware import LoggingMiddleware
 import app.models
@@ -29,6 +32,10 @@ with SessionLocal() as db:
 app = FastAPI(title="adm_TA")
 
 app.add_middleware(LoggingMiddleware)
+app.add_middleware(SessionMiddleware, secret_key=settings.JWT_SECRET_KEY)
+
+app.mount("/static", StaticFiles(directory="app/static"), name="static")
 
 app.include_router(auth.router)
 app.include_router(registration.router)
+app.include_router(pages.router)

--- a/app/static/css/style.css
+++ b/app/static/css/style.css
@@ -1,0 +1,3 @@
+body {
+    font-family: Arial, sans-serif;
+}

--- a/app/static/js/main.js
+++ b/app/static/js/main.js
@@ -1,0 +1,1 @@
+// Placeholder for global scripts

--- a/app/templates/login.html
+++ b/app/templates/login.html
@@ -1,0 +1,44 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+    <meta charset="UTF-8">
+    <title>Login</title>
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet">
+    <link rel="stylesheet" href="{{ url_for('static', path='/css/style.css') }}">
+</head>
+<body class="bg-light">
+    <div class="container mt-5">
+        <div class="row justify-content-center">
+            <div class="col-md-4">
+                <div class="text-center mb-4">
+                    <img src="{{ url_for('static', path='/img/logo.png') }}" alt="Logo" class="img-fluid" style="max-height: 100px;">
+                </div>
+                {% if error %}
+                <div class="alert alert-danger">{{ error }}</div>
+                {% endif %}
+                <form method="post" action="/login">
+                    <div class="mb-3">
+                        <label class="form-label">Email</label>
+                        <input type="text" class="form-control" name="username" required>
+                    </div>
+                    <div class="mb-3">
+                        <label class="form-label">Contraseña</label>
+                        <input type="password" class="form-control" name="password" required>
+                    </div>
+                    <div class="d-grid gap-2">
+                        <button type="submit" class="btn btn-primary">Ingresar</button>
+                    </div>
+                </form>
+                <div class="d-grid gap-2 mt-3">
+                    <a class="btn btn-outline-danger" href="/auth/google">Ingresar con Google</a>
+                </div>
+                <p class="mt-3 text-center">
+                    ¿No tienes cuenta? <a href="/register">Regístrate</a>
+                </p>
+            </div>
+        </div>
+    </div>
+    <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>
+    <script src="{{ url_for('static', path='/js/main.js') }}"></script>
+</body>
+</html>

--- a/app/templates/register.html
+++ b/app/templates/register.html
@@ -1,0 +1,51 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+    <meta charset="UTF-8">
+    <title>Registro</title>
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet">
+    <link rel="stylesheet" href="{{ url_for('static', path='/css/style.css') }}">
+</head>
+<body class="bg-light">
+    <div class="container mt-5">
+        <div class="row justify-content-center">
+            <div class="col-md-6">
+                <h2 class="mb-4 text-center">Registro</h2>
+                {% if error %}
+                <div class="alert alert-danger">{{ error }}</div>
+                {% endif %}
+                <form method="post" action="/register">
+                    <div class="row">
+                        <div class="col-md-6 mb-3">
+                            <label class="form-label">Nombre</label>
+                            <input type="text" class="form-control" name="first_name" required>
+                        </div>
+                        <div class="col-md-6 mb-3">
+                            <label class="form-label">Apellido</label>
+                            <input type="text" class="form-control" name="last_name" required>
+                        </div>
+                    </div>
+                    <div class="mb-3">
+                        <label class="form-label">Email</label>
+                        <input type="email" class="form-control" name="email" required>
+                    </div>
+                    <div class="mb-3">
+                        <label class="form-label">Contraseña</label>
+                        <input type="password" class="form-control" name="password" required>
+                    </div>
+                    <div class="mb-3">
+                        <label class="form-label">Confirmar contraseña</label>
+                        <input type="password" class="form-control" name="confirm_password" required>
+                    </div>
+                    <div class="d-grid">
+                        <button class="btn btn-primary" type="submit">Registrarse</button>
+                    </div>
+                </form>
+                <p class="mt-3 text-center"><a href="/login">Volver al login</a></p>
+            </div>
+        </div>
+    </div>
+    <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>
+    <script src="{{ url_for('static', path='/js/main.js') }}"></script>
+</body>
+</html>

--- a/app/templates/welcome.html
+++ b/app/templates/welcome.html
@@ -1,0 +1,34 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+    <meta charset="UTF-8">
+    <title>Bienvenido</title>
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet">
+    <link rel="stylesheet" href="{{ url_for('static', path='/css/style.css') }}">
+</head>
+<body>
+<nav class="navbar navbar-light bg-light justify-content-between">
+    <a class="navbar-brand ms-3">Bienvenido</a>
+    <div class="dropdown me-3">
+        <a class="d-flex align-items-center text-decoration-none dropdown-toggle" href="#" id="userMenu" data-bs-toggle="dropdown" aria-expanded="false">
+            <img src="{{ url_for('static', path='/img/user.png') }}" alt="user" width="32" height="32" class="rounded-circle me-2">
+            <strong>{{ user_name }}</strong>
+        </a>
+        <ul class="dropdown-menu dropdown-menu-end" aria-labelledby="userMenu">
+            <li><a class="dropdown-item" href="#">Opciones</a></li>
+            <li><hr class="dropdown-divider"></li>
+            <li>
+                <form method="post" action="/logout" class="d-inline">
+                    <button class="dropdown-item" type="submit">Cerrar sesión</button>
+                </form>
+            </li>
+        </ul>
+    </div>
+</nav>
+<div class="container mt-5">
+    <h1>Bienvenido, {{ user_name }}!</h1>
+</div>
+<script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>
+<script src="{{ url_for('static', path='/js/main.js') }}"></script>
+</body>
+</html>

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,3 +9,4 @@ python-dotenv
 python-multipart
 requests
 pydantic[email]
+itsdangerous


### PR DESCRIPTION
## Summary
- add HTML templates for login, registration and welcome screens
- implement session-based auth and logout routes
- serve static assets, mount pages router, and include session middleware
- add itsdangerous dependency for session support

## Testing
- `pip install -r requirements.txt`
- `python -m py_compile app/api/routers/pages.py app/main.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6896cc0033848332a37cf521668c55d7