### PR TITLE
Add Jinja2 dependency for templates

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -10,3 +10,4 @@ python-multipart
 requests
 pydantic[email]
 itsdangerous
+jinja2


### PR DESCRIPTION
## Summary
- include Jinja2 in Python requirements to enable template rendering

## Testing
- `pip install -r requirements.txt`
- `python - <<'PY'
from starlette.templating import Jinja2Templates
Jinja2Templates(directory='app/templates')
print('ok')
PY`

------
https://chatgpt.com/codex/tasks/task_e_6896d74d72d08332b1d1ab782f12597d