### PR TITLE
Redirect root to docs and pin bcrypt version

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,1 @@
+postgres_data

--- a/.env.example
+++ b/.env.example
@@ -2,7 +2,7 @@ POSTGRES_USER=postgres
 POSTGRES_PASSWORD=postgres
 POSTGRES_DB=db_TA
 POSTGRES_PORT=5432
-DATABASE_URL=postgresql+psycopg2://postgres:postgres@db_TA:5432/db_TA
+DATABASE_URL=postgresql+psycopg2://postgres:postgres@db:5432/db_TA
 DB_PATH=./postgres_data
 
 JWT_SECRET_KEY=changeme

--- a/app/main.py
+++ b/app/main.py
@@ -1,4 +1,5 @@
 from fastapi import FastAPI
+from fastapi.responses import RedirectResponse
 from fastapi.staticfiles import StaticFiles
 from starlette.middleware.sessions import SessionMiddleware
 
@@ -30,6 +31,13 @@ with SessionLocal() as db:
         db.commit()
 
 app = FastAPI(title="adm_TA")
+
+
+@app.get("/", include_in_schema=False)
+def root() -> RedirectResponse:
+    """Redirect base path to interactive API docs."""
+    return RedirectResponse("/docs")
+
 
 app.add_middleware(LoggingMiddleware)
 app.add_middleware(SessionMiddleware, secret_key=settings.JWT_SECRET_KEY)

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,8 @@ uvicorn
 SQLAlchemy
 psycopg2-binary
 python-jose
-passlib[bcrypt]
+passlib[bcrypt]==1.7.4
+bcrypt==4.0.1
 python-dotenv
 python-multipart
 requests


### PR DESCRIPTION
## Summary
- Redirect `/` to FastAPI docs to avoid 404
- Pin `bcrypt==4.0.1` alongside `passlib[bcrypt]==1.7.4`
- Update DB host to `db` and add `.dockerignore`

## Testing
- `pip install -r requirements.txt`
- `docker-compose build --no-cache adm` *(fails: Error while fetching server API version)*
- `python -m py_compile app/main.py`


------
https://chatgpt.com/codex/tasks/task_e_6896d9b117048332b845c6b30ccf464a